### PR TITLE
Allow MMB block pick while player cannot build

### DIFF
--- a/core/src/mindustry/ui/fragments/PlacementFragment.java
+++ b/core/src/mindustry/ui/fragments/PlacementFragment.java
@@ -100,7 +100,7 @@ public class PlacementFragment extends Fragment{
     boolean gridUpdate(InputHandler input){
         scrollPositions.put(currentCategory, blockPane.getScrollY());
 
-        if(Core.input.keyTap(Binding.pick) && player.isBuilder()){ //mouse eyedropper select
+        if(Core.input.keyTap(Binding.pick) /*&& player.isBuilder()*/){ //mouse eyedropper select
             var build = world.buildWorld(Core.input.mouseWorld().x, Core.input.mouseWorld().y);
             Block tryRecipe = build == null ? null : build instanceof ConstructBuild c ? c.current : build.block;
             Object tryConfig = build == null || !build.block.copyConfig ? null : build.config();


### PR DESCRIPTION
allows it to be more consistent with other behavior (eg. making build plans), when the player is unable to build.