### PR TITLE
Small tweaks in processor menu

### DIFF
--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -356,11 +356,13 @@ public class LCanvas extends Table{
                     this.paste(LAssembler.read(Core.app.getClipboardText().replace("\r\n", "\n")));
                 });
 
-                t.button(Icon.cancel, Styles.logici, () -> {
+                var temp = t.button(Icon.cancel, Styles.logici, () -> {
                     remove();
                     dragging = null;
                     statements.layout();
                 }).size(24f);
+                temp.get().tapped(() -> isDeleting = true);
+                temp.get().released(() -> isDeleting = false);
 
                 t.addListener(new InputListener(){
                     float lastx, lasty;

--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -323,6 +323,7 @@ public class LCanvas extends Table{
         public LStatement st;
         public int index;
         Label addressLabel;
+        private boolean isDeleting = false;
 
         public StatementElem(LStatement st){
             this.st = st;
@@ -374,6 +375,7 @@ public class LCanvas extends Table{
                             copy();
                             return false;
                         }
+                        if(isDeleting) return false;
 
                         Vec2 v = localToParentCoordinates(Tmp.v1.set(x, y));
                         lastx = v.x;

--- a/core/src/mindustry/logic/LCanvas.java
+++ b/core/src/mindustry/logic/LCanvas.java
@@ -354,7 +354,8 @@ public class LCanvas extends Table{
 
                 t.button(Icon.paste, Styles.logici, () -> {
                 }).size(24f).padRight(6).tooltip("Paste Here").get().tapped(() -> {
-                    this.paste(LAssembler.read(Core.app.getClipboardText().replace("\r\n", "\n")));
+                    try{ this.paste(LAssembler.read(Core.app.getClipboardText().replace("\r\n", "\n"))); }
+                    catch(Throwable e){Vars.ui.showException(e);};
                 });
 
                 var temp = t.button(Icon.cancel, Styles.logici, () -> {


### PR DESCRIPTION
- click-dragging the x button of a logic statement now does not drag the entire statement along with it
- the clipboard processor crash fix thing stolen from LogicDialog:60