### PR TITLE
Allow connecting bridges one tile away without the inventory display overlapping

### DIFF
--- a/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
+++ b/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
@@ -235,7 +235,7 @@ public class BlockInventoryFragment{
 
         //Position the table diagonally when the building is an item bridge so that connecting to another bridge one
         //tile away is possible without the overlay preventing the click.
-        table.setPosition(v.x, v.y, this.build instanceof ItemBridge.ItemBridgeBuild ? Align.bottomLeft: Align.topLeft);
+        table.setPosition(v.x, v.y, build.block instanceof ItemBridge ? Align.bottomLeft : Align.topLeft);
     }
 
     private Element itemImage(TextureRegion region, Prov<CharSequence> text){

--- a/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
+++ b/core/src/mindustry/ui/fragments/BlockInventoryFragment.java
@@ -18,6 +18,7 @@ import mindustry.core.*;
 import mindustry.game.EventType.*;
 import mindustry.gen.*;
 import mindustry.type.*;
+import mindustry.world.blocks.distribution.ItemBridge;
 import mindustry.world.blocks.payloads.*;
 
 import java.util.*;
@@ -231,7 +232,10 @@ public class BlockInventoryFragment{
     private void updateTablePosition(){
         Vec2 v = input.mouseScreen(build.x + build.block.size * tilesize / 2f, build.y + build.block.size * tilesize / 2f);
         table.pack();
-        table.setPosition(v.x, v.y, Align.topLeft);
+
+        //Position the table diagonally when the building is an item bridge so that connecting to another bridge one
+        //tile away is possible without the overlay preventing the click.
+        table.setPosition(v.x, v.y, this.build instanceof ItemBridge.ItemBridgeBuild ? Align.bottomLeft: Align.topLeft);
     }
 
     private Element itemImage(TextureRegion region, Prov<CharSequence> text){


### PR DESCRIPTION
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.

Before looking at the PR, could you please confirm that bridge item overlays are a Foo-only thing and that this isn't in Vanilla yet? I checked out the latest master from the upstream repo and couldn't see it. If so, please let me know and I'll file this pull request with Anuke.

## Motivation

Previously, the item display of bridges would prevent connecting them one tile away (if built from left to right):
![image](https://github.com/mindustry-antigrief/mindustry-client/assets/7313176/5a644745-3447-4228-a9ad-456f4e2f7d39)

You'd need to zoom in all the way to be able to connect them.

## Proposed Solution

With this change, for bridges only, the item fragment will be aligned diagonally so that connecting the bridge becomes possible without interference:
![image](https://github.com/mindustry-antigrief/mindustry-client/assets/7313176/9e97f5ed-e495-41a4-9db5-63b6f3c07b7c)

I'm not sure if this is the cleanest fix, but I think in all the other cases the current position of the overlay is fine, so changing it only for this especially annoying case should be alright. I'm open to suggestions and ideas.

