### PR TITLE
Fixes

### DIFF
--- a/core/src/mindustry/input/InputHandler.java
+++ b/core/src/mindustry/input/InputHandler.java
@@ -1401,7 +1401,10 @@ public abstract class InputHandler implements InputProcessor, GestureListener{
             if (plan.block == Blocks.waterExtractor && !input.shift() // Attempt to replace water extractors with pumps FINISHME: Don't place 4 pumps, only 2 needed.
                     && plan.tile() != null && plan.tile().getLinkedTilesAs(plan.block, tempTiles).contains(t -> t.floor().liquidDrop == Liquids.water)) { // Has water
                 var first = tempTiles.first();
-                if (tempTiles.contains(t -> !t.adjacentTo(first) && t != first && t.floor().liquidDrop == Liquids.water)
+                // As long as there is a diagonal, all adjacent blocks are hydrated
+                boolean coversOutputs = (tempTiles.get(0).floor().liquidDrop == Liquids.water && tempTiles.get(3).floor().liquidDrop  == Liquids.water) ||
+                        (tempTiles.get(1).floor().liquidDrop == Liquids.water && tempTiles.get(2).floor().liquidDrop  == Liquids.water);
+                if (coversOutputs
                         && !tempTiles.contains(t -> !validPlace(t.x, t.y, t.floor().liquidDrop == Liquids.water ? Blocks.mechanicalPump : Blocks.liquidJunction, 0))) { // Can use mechanical pumps (covers all outputs)
                     for (var t : tempTiles) temp[added++] = new BuildPlan(t.x, t.y, 0, t.floor().liquidDrop == Liquids.water ? Blocks.mechanicalPump : Blocks.liquidJunction);
                     continue; // Swapped water extractor for mechanical pumps, don't place it

--- a/core/src/mindustry/world/blocks/storage/Unloader.java
+++ b/core/src/mindustry/world/blocks/storage/Unloader.java
@@ -232,7 +232,7 @@ public class Unloader extends Block{
 
             Draw.color(sortItem == null ? customNullLoader ? Pal.lightishGray : Color.clear : sortItem.color);
             Draw.rect(centerRegion, x, y);
-            if(drawUnloaderItems && lastItem != null && dumpingFrom != null && dumpingTo != null && enabled){
+            if(drawUnloaderItems && possibleBlocks.size >= 2 && lastItem != null && dumpingFrom != null && dumpingTo != null && enabled){
                 Draw.color(lastItem.color, 0.67f);
                 Draw.rect("unloader-center", x, y);
                 Draw.alpha(1f);


### PR DESCRIPTION
1. Unloaders aren't active when possibleBlocks < 2 hence we don't draw arrows 
2. Previous behavior was incorrect as the diagonal does not get water. Fix assumes the water extractor is always 2x2 and the behavior of getLinkedTilesAs doesn't change

https://github.com/user-attachments/assets/d2848467-c123-4de2-98f1-e4cc4fd34934

https://github.com/user-attachments/assets/9d4eee47-4579-465a-89c1-fb5715e14844

https://github.com/user-attachments/assets/7188d8ed-50b7-4d02-9d0b-3a4d73d79dc1



